### PR TITLE
Support PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "hampe/inky": "^1.3.6.2",
+        "filipegar/inky": "^1.3.7",
         "illuminate/support": "~5.1",
         "illuminate/view": "~5.1",
         "symfony/css-selector": "^2.7|^3.0",


### PR DESCRIPTION
Hello, @petecoop 
I replaced hampe/inky with filipegar/inky to support PHP 7.2.
The main problem here is that hampe requires an obsolete package. As that repo is no longer mantained, I forked and replaced the dependencies with newer ones.
